### PR TITLE
Markerclusterer changed the filename of their packed js

### DIFF
--- a/lib/v3/cartographer/header.rb
+++ b/lib/v3/cartographer/header.rb
@@ -33,7 +33,7 @@ class Cartographer::Header
     html = "\n<!--[if IE]>\n<style type=\"text/css\">v\\:* { behavior:url(#default#VML); }</style>\n<![endif]-->"
     html << "<script type=\"text/javascript\" src=\"http://maps.google.com/maps/api/js?sensor=true&libraries=adsense\"></script>"
     html << "<script src='http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markermanager/src/markermanager_packed.js' type='text/javascript'></script>"
-    html << "<script src='http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/src/markerclusterer_packed.js' type='text/javascript'></script>"
+    html << "<script src='http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/src/markerclusterer_compiled.js' type='text/javascript'></script>"
        
     return html
   end


### PR DESCRIPTION
markercluster_packed.js no longer exists in 

```
http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/src/
```

It seems they've renamed it to `markerclusterer_compiled.js`

This definitely affects v3, not sure about v2.

Cheers
